### PR TITLE
Check for errors when grabbing the story by id

### DIFF
--- a/src/UNL/ENews/StoryList.php
+++ b/src/UNL/ENews/StoryList.php
@@ -26,6 +26,12 @@ class UNL_ENews_StoryList extends LimitIterator implements Countable
      */
     function current()
     {
-        return UNL_ENews_Story::getByID(parent::current());
+        $story = UNL_ENews_Story::getByID(parent::current());
+
+        if (!$story) {
+            throw new Exception('The story with id of '.(int)parent::current().' does not exist!');
+        }
+
+        return $story;
     }
 }


### PR DESCRIPTION
When iterating over a list of stories a story may not be present. This could happen when a database error occurs and the newsletter_stories table contains references to stories that do not exist.
