### PR TITLE
Set story data_modified when the record was created 

### DIFF
--- a/src/UNL/ENews/Story.php
+++ b/src/UNL/ENews/Story.php
@@ -41,6 +41,7 @@ class UNL_ENews_Story extends UNL_ENews_Record
         if (empty($this->id)) {
             $this->uid_created    = strtolower(UNL_ENews_Controller::getUser(true)->uid);
             $this->date_submitted = date('Y-m-d H:i:s');
+            $this->date_modified  = date('Y-m-d H:i:s');
         } else {
             $this->uid_modified   = strtolower(UNL_ENews_Controller::getUser(true)->uid);
             $this->date_modified  = date('Y-m-d H:i:s');


### PR DESCRIPTION
This change is meant to help with the migration to Drupal.  It will allow the use of a feature called `highwater marks` which should increase performance of the continuous migration.

```
If the source data contains a timestamp that is set to the creation time of each new item, and changed to the update time every time the item is updated, then you can have those updated items automatically reimported by setting the field as your highwater field.
```

https://drupal.org/node/1223936
