### PR TITLE
Update js references to 3.1

### DIFF
--- a/www/js/preview.js
+++ b/www/js/preview.js
@@ -37,7 +37,7 @@ var preview = function($) {
 				$('.story .story-content a').live('click', function(e) {
 					return false;
 				})
-				WDN.loadJS('/wdn/templates_3.0/scripts/plugins/hoverIntent/jQuery.hoverIntent.min.js', preview.setupToolsHover);
+				WDN.loadJS('/wdn/templates_3.1/scripts/plugins/hoverIntent/jQuery.hoverIntent.min.js', preview.setupToolsHover);
 				preview.setupDragAndSort();
 				preview.initDraggable($('.adArea .story'));
 			});

--- a/www/templates/html/ENews/Newsletter/Preview.tpl.php
+++ b/www/templates/html/ENews/Newsletter/Preview.tpl.php
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-    WDN.loadJS("/wdn/templates_3.0/scripts/plugins/ui/jQuery.ui.js",function(){
+    WDN.loadJS("/wdn/templates_3.1/scripts/plugins/ui/jQuery.ui.js",function(){
         WDN.jQuery("#releaseDate").datepicker({
             showOn: 'both',
             buttonImage: '/wdn/templates_3.0/css/content/images/mimetypes/x-office-calendar.png',
@@ -10,9 +10,9 @@
             preview.initialize();
         });
     });
-    WDN.loadCSS("/wdn/templates_3.0/css/content/forms.css");
-    WDN.loadCSS("/wdn/templates_3.0/scripts/plugins/ui/jquery-ui.css");
-    WDN.loadCSS("/wdn/templates_3.0/scripts/plugins/ui/ui.datepicker.css");
+    WDN.loadCSS("/wdn/templates_3.1/css/content/forms.css");
+    WDN.loadCSS("/wdn/templates_3.1/scripts/plugins/ui/jquery-ui.css");
+    WDN.loadCSS("/wdn/templates_3.1/scripts/plugins/ui/ui.datepicker.css");
 </script>
 
 <div id="newsletterDetails">

--- a/www/templates/html/ENews/Newsroom/Stories.tpl.php
+++ b/www/templates/html/ENews/Newsroom/Stories.tpl.php
@@ -15,12 +15,14 @@ if (count($context) == 0) {
 ?>
 
 
+<script src="<?php echo UNL_ENews_Controller::getURL();?>/js/manager.js" type="text/javascript"></script>
 <script type="text/javascript">
-WDN.loadJS("/wdn/templates_3.0/scripts/plugins/ui/jQuery.ui.js");
-WDN.loadJS("<?php echo UNL_ENews_Controller::getURL();?>/js/manager.js",function(){
-	manager.initialize();
-});
-WDN.loadCSS("/wdn/templates_3.0/css/content/forms.css");
+    WDN.loadJS("/wdn/templates_3.1/scripts/plugins/ui/jQuery.ui.js");
+    WDN.loadCSS("/wdn/templates_3.1/css/content/forms.css");
+
+    WDN.jQuery(document).ready(function() {
+        manager.initialize();
+    });
 </script>
 
 <form id="enewsManage" name="enewsManage" class="energetic" method="post" action="<?php echo $context->getManageURL(); ?>">

--- a/www/themes/MockU/html/ENews/Controller.tpl.php
+++ b/www/themes/MockU/html/ENews/Controller.tpl.php
@@ -4,7 +4,7 @@
 <link rel="stylesheet" type="text/css" media="screen" href="<?php echo UNL_ENews_Controller::getURL();?>css/all.css" />
 
 <title><?php echo $savvy->render($context, 'ENews/PageTitle.tpl.php'); ?> E-News | MockU</title>
-<script type="text/javascript" src="/wdn/templates_3.0/scripts/all.js"></script>
+<script type="text/javascript" src="/wdn/templates_3.1/scripts/all.js"></script>
 <script type="text/javascript">
 var ENEWS_HOME = '<?php echo UNL_ENews_Controller::getURL(); ?>';
 </script>


### PR DESCRIPTION
Fixes IE9 issues with drag and drop.  A quick fix until 4.0 is released.
#44

When 4.0 is released, it might be worth while to convert the project to the 4.0 framework as a lot of newsrooms will still be using this system for some time.
