### PR TITLE
Allow some HTML markup in the description and full_article fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "require": {
-    "widop/google-analytics": "*"
+    "widop/google-analytics": "*",
+    "ezyang/htmlpurifier": "~4.6"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,52 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e8138059950269e4f19e862689fb58ed",
+    "hash": "582e61da02c08364d1e1f205aa8e2757",
     "packages": [
+        {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "ae1828d955112356f7677c465f94f7deb7d27a40"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/ae1828d955112356f7677c465f94f7deb7d27a40",
+                "reference": "ae1828d955112356f7677c465f94f7deb7d27a40",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "time": "2015-08-05 01:03:42"
+        },
         {
             "name": "widop/google-analytics",
             "version": "1.0.0",

--- a/src/UNL/ENews/Controller.php
+++ b/src/UNL/ENews/Controller.php
@@ -37,7 +37,7 @@ class UNL_ENews_Controller
      * 
      * @var string
      */
-    public static $allowed_html_field_description = 'a[href],strong,p,em';
+    public static $allowed_html_field_description = 'a[href],strong,p,em,br';
 
     /**
      * See http://htmlpurifier.org/live/configdoc/plain.html#HTML.Allowed
@@ -45,7 +45,7 @@ class UNL_ENews_Controller
      * 
      * @var string
      */
-    public static $allowed_html_field_full_article = 'a[href],strong,p,ul,ol,li,em';
+    public static $allowed_html_field_full_article = 'a[href],strong,p,ul,ol,li,em,br';
 
     /**
      * See https://github.com/cure53/DOMPurify#can-i-configure-it
@@ -53,7 +53,7 @@ class UNL_ENews_Controller
      * 
      * @var array
      */
-    public static $js_allowed_tags_description = array('a','strong','p','em');
+    public static $js_allowed_tags_description = array('a','strong','p','em','br');
 
     /**
      * See https://github.com/cure53/DOMPurify#can-i-configure-it

--- a/src/UNL/ENews/Controller.php
+++ b/src/UNL/ENews/Controller.php
@@ -31,6 +31,38 @@ class UNL_ENews_Controller
 
     public $actionable = array();
 
+    /**
+     * See http://htmlpurifier.org/live/configdoc/plain.html#HTML.Allowed
+     * Maps to the htmlpurifier config option HTML.Allowed
+     * 
+     * @var string
+     */
+    public static $allowed_html_field_description = 'a[href],strong,p,em';
+
+    /**
+     * See http://htmlpurifier.org/live/configdoc/plain.html#HTML.Allowed
+     * Maps to the htmlpurifier config option HTML.Allowed
+     * 
+     * @var string
+     */
+    public static $allowed_html_field_full_article = 'a[href],strong,p,ul,ol,li,em';
+
+    /**
+     * See https://github.com/cure53/DOMPurify#can-i-configure-it
+     * Maps to the DOMPurify config option `ALLOWED_TAGS`
+     * 
+     * @var array
+     */
+    public static $js_allowed_tags_description = array('a','strong','p','em');
+
+    /**
+     * See https://github.com/cure53/DOMPurify#can-i-configure-it
+     * Maps to the DOMPurify config option `ALLOWED_ATTR`
+     * 
+     * @var array
+     */
+    public static $js_allowed_attr_description = array('href');
+
     function __construct($options = array())
     {
         $this->options = $options + $this->options;

--- a/src/UNL/ENews/Controller.php
+++ b/src/UNL/ENews/Controller.php
@@ -279,9 +279,8 @@ class UNL_ENews_Controller
     {
         //make sure there is an http:// on all URLs
         $string = preg_replace("/([^\w\/])(www\.[a-z0-9\-]+\.[a-z0-9\-]+)/i", "$1http://$2",$string);
-        // make all URLs links
-        $string = preg_replace("/([\w]+:\/\/[\w-?&;#~\+=\.\/\@]+[\w\/])/i","<a href=\"$1\">$1</a>",$string);
-        // make all emails links
+        
+        // make all emails links (not done with HTML Purifier)
         $string = preg_replace("/([\w-?&;#~=\.\/]+\@(\[?)[a-zA-Z0-9\-\.]+\.([a-zA-Z]{2,4}|[0-9]{1,4})(\]?))/i","<a href=\"mailto:$1\">$1</a>",$string);
 
         return $string;

--- a/src/UNL/ENews/GAStats.php
+++ b/src/UNL/ENews/GAStats.php
@@ -1,6 +1,5 @@
 <?php
 require dirname(__FILE__).'/../../../lib/php/gapi.class.php';
-require dirname(__FILE__).'/../../../vendor/autoload.php';
 
 use Widop\GoogleAnalytics\Query;
 use Widop\GoogleAnalytics\Client;

--- a/www/index.php
+++ b/www/index.php
@@ -5,6 +5,8 @@ if (file_exists('config.inc.php')) {
     require 'config.sample.php';
 }
 
+require dirname(__FILE__).'/../vendor/autoload.php';
+
 $routes = include __DIR__ . '/../data/routes.php';
 
 $router = new RegExpRouter\Router(array('baseURL' => UNL_ENews_Controller::$url));

--- a/www/js/purify.js
+++ b/www/js/purify.js
@@ -1,0 +1,760 @@
+;(function(factory) {
+    'use strict';
+    /* global window: false, define: false, module: false */
+    var root = typeof window === 'undefined' ? null : window;
+
+    if (typeof define === 'function' && define.amd) {
+        define(function(){ return factory(root); });
+    } else if (typeof module !== 'undefined') {
+        module.exports = factory(root);
+    } else {
+        root.DOMPurify = factory(root);
+    }
+}(function factory(window) {
+    'use strict';
+
+    var DOMPurify = function(window) {
+        return factory(window);
+    };
+
+    /**
+     * Version label, exposed for easier checks
+     * if DOMPurify is up to date or not
+     */
+    DOMPurify.version = '0.7.2';
+
+    if (!window || !window.document || window.document.nodeType !== 9) {
+        // not running in a browser, provide a factory function
+        // so that you can pass your own Window
+        DOMPurify.isSupported = false;
+        return DOMPurify;
+    }
+
+    var document = window.document;
+    var originalDocument = document;
+    var DocumentFragment = window.DocumentFragment;
+    var HTMLTemplateElement = window.HTMLTemplateElement;
+    var NodeFilter = window.NodeFilter;
+    var NamedNodeMap = window.NamedNodeMap || window.MozNamedAttrMap;
+    var Text = window.Text;
+    var Comment = window.Comment;
+    var DOMParser = window.DOMParser;
+
+    // As per issue #47, the web-components registry is inherited by a
+    // new document created via createHTMLDocument. As per the spec
+    // (http://w3c.github.io/webcomponents/spec/custom/#creating-and-passing-registries)
+    // a new empty registry is used when creating a template contents owner
+    // document, so we use that as our parent document to ensure nothing
+    // is inherited.
+    if (typeof HTMLTemplateElement === 'function') {
+        document = document.createElement('template').content.ownerDocument;
+    }
+    var implementation = document.implementation;
+    var createNodeIterator = document.createNodeIterator;
+    var getElementsByTagName = document.getElementsByTagName;
+    var createDocumentFragment = document.createDocumentFragment;
+    var importNode = originalDocument.importNode;
+
+    var hooks = {};
+
+    /**
+     * Expose whether this browser supports running the full DOMPurify.
+     */
+    DOMPurify.isSupported =
+        typeof implementation.createHTMLDocument !== 'undefined' &&
+        document.documentMode !== 9;
+
+    /* Add properties to a lookup table */
+    var _addToSet = function(set, array) {
+        var l = array.length;
+        while (l--) {
+            set[array[l]] = true;
+        }
+        return set;
+    };
+
+    /* Shallow clone an object */
+    var _cloneObj = function(object) {
+        var newObject = {};
+        var property;
+        for (property in object) {
+            if (object.hasOwnProperty(property)) {
+                newObject[property] = object[property];
+            }
+        }
+        return newObject;
+    };
+
+    /**
+     * We consider the elements and attributes below to be safe. Ideally
+     * don't add any new ones but feel free to remove unwanted ones.
+     */
+
+    /* allowed element names */
+    var ALLOWED_TAGS = null;
+    var DEFAULT_ALLOWED_TAGS = _addToSet({}, [
+
+        // HTML
+        'a','abbr','acronym','address','area','article','aside','audio','b',
+        'bdi','bdo','big','blink','blockquote','body','br','button','canvas',
+        'caption','center','cite','code','col','colgroup','content','data',
+        'datalist','dd','decorator','del','details','dfn','dir','div','dl','dt',
+        'element','em','fieldset','figcaption','figure','font','footer','form',
+        'h1','h2','h3','h4','h5','h6','head','header','hgroup','hr','html','i',
+        'img','input','ins','kbd','label','legend','li','main','map','mark',
+        'marquee','menu','menuitem','meter','nav','nobr','ol','optgroup',
+        'option','output','p','pre','progress','q','rp','rt','ruby','s','samp',
+        'section','select','shadow','small','source','spacer','span','strike',
+        'strong','style','sub','summary','sup','table','tbody','td','template',
+        'textarea','tfoot','th','thead','time','tr','track','tt','u','ul','var',
+        'video','wbr',
+
+        // SVG
+        'svg','altglyph','altglyphdef','altglyphitem','animatecolor',
+        'animatemotion','animatetransform','circle','clippath','defs','desc',
+        'ellipse','font','g','glyph','glyphref','hkern','image','line',
+        'lineargradient','marker','mask','metadata','mpath','path','pattern',
+        'polygon','polyline','radialgradient','rect','stop','switch','symbol',
+        'text','textpath','title','tref','tspan','view','vkern',
+
+        //MathML
+        'math','menclose','merror','mfenced','mfrac','mglyph','mi','mlabeledtr',
+        'mmuliscripts','mn','mo','mover','mpadded','mphantom','mroot','mrow',
+        'ms','mpspace','msqrt','mystyle','msub','msup','msubsup','mtable','mtd',
+        'mtext','mtr','munder','munderover',
+
+        //Text
+        '#text'
+    ]);
+
+    /* Allowed attribute names */
+    var ALLOWED_ATTR = null;
+    var DEFAULT_ALLOWED_ATTR = _addToSet({}, [
+
+        // HTML
+        'accept','action','align','alt','autocomplete','background','bgcolor',
+        'border','cellpadding','cellspacing','checked','cite','class','clear','color',
+        'cols','colspan','coords','datetime','default','dir','disabled',
+        'download','enctype','face','for','headers','height','hidden','high','href',
+        'hreflang','id','ismap','label','lang','list','loop', 'low','max',
+        'maxlength','media','method','min','multiple','name','noshade','novalidate',
+        'nowrap','open','optimum','pattern','placeholder','poster','preload','pubdate',
+        'radiogroup','readonly','rel','required','rev','reversed','rows',
+        'rowspan','spellcheck','scope','selected','shape','size','span',
+        'srclang','start','src','step','style','summary','tabindex','title',
+        'type','usemap','valign','value','width','xmlns',
+
+        // SVG
+        'accent-height','accumulate','additivive','alignment-baseline',
+        'ascent','azimuth','baseline-shift','bias','clip','clip-path',
+        'clip-rule','color','color-interpolation','color-interpolation-filters',
+        'color-profile','color-rendering','cx','cy','d','dy','dy','direction',
+        'display','divisor','dur','elevation','end','fill','fill-opacity',
+        'fill-rule','filter','flood-color','flood-opacity','font-family',
+        'font-size','font-size-adjust','font-stretch','font-style','font-variant',
+        'font-weight','image-rendering','in','in2','k1','k2','k3','k4','kerning',
+        'letter-spacing','lighting-color','local','marker-end','marker-mid',
+        'marker-start','max','mask','mode','min','offset','operator','opacity',
+        'order','overflow','paint-order','path','points','r','rx','ry','radius',
+        'restart','scale','seed','shape-rendering','stop-color','stop-opacity',
+        'stroke-dasharray','stroke-dashoffset','stroke-linecap','stroke-linejoin',
+        'stroke-miterlimit','stroke-opacity','stroke','stroke-width','transform',
+        'text-anchor','text-decoration','text-rendering','u1','u2','viewbox',
+        'visibility','word-spacing','wrap','writing-mode','x','x1','x2','y',
+        'y1','y2','z',
+
+        // MathML
+        'accent','accentunder','bevelled','close','columnsalign','columnlines',
+        'columnspan','denomalign','depth','display','displaystyle','fence',
+        'frame','largeop','length','linethickness','lspace','lquote',
+        'mathbackground','mathcolor','mathsize','mathvariant','maxsize',
+        'minsize','movablelimits','notation','numalign','open','rowalign',
+        'rowlines','rowspacing','rowspan','rspace','rquote','scriptlevel',
+        'scriptminsize','scriptsizemultiplier','selection','separator',
+        'separators','stretchy','subscriptshift','supscriptshift','symmetric',
+        'voffset',
+
+        // XML
+        'xlink:href','xml:id','xlink:title','xml:space','xmlns:xlink'
+    ]);
+
+    /* Explicitly forbidden tags (overrides ALLOWED_TAGS/ADD_TAGS) */
+    var FORBID_TAGS = null;
+
+    /* Explicitly forbidden attributes (overrides ALLOWED_ATTR/ADD_ATTR) */
+    var FORBID_ATTR = null;
+
+    /* Decide if custom data attributes are okay */
+    var ALLOW_DATA_ATTR = true;
+
+    /* Output should be safe for jQuery's $() factory? */
+    var SAFE_FOR_JQUERY = false;
+
+    /* Output should be safe for common template engines.
+     * This means, DOMPurify removes data attributes, mustaches and ERB 
+     */
+    var SAFE_FOR_TEMPLATES = false;
+
+     /* Decide if document with <html>... should be returned */
+    var WHOLE_DOCUMENT = false;
+
+    /* Decide if a DOM `HTMLBodyElement` should be returned, instead of a html string.
+     * If `WHOLE_DOCUMENT` is enabled a `HTMLHtmlElement` will be returned instead
+     */
+    var RETURN_DOM = false;
+
+    /* Decide if a DOM `DocumentFragment` should be returned, instead of a html string */
+    var RETURN_DOM_FRAGMENT = false;
+
+    /* If `RETURN_DOM` or `RETURN_DOM_FRAGMENT` is enabled, decide if the returned DOM
+     * `Node` is imported into the current `Document`. If this flag is not enabled the
+     * `Node` will belong (its ownerDocument) to a fresh `HTMLDocument`, created by
+     * DOMPurify. */
+    var RETURN_DOM_IMPORT = false;
+
+    /* Output should be free from DOM clobbering attacks? */
+    var SANITIZE_DOM = true;
+
+    /* Keep element content when removing element? */
+    var KEEP_CONTENT = true;
+
+    /* Tags to ignore content of when KEEP_CONTENT is true */
+    var FORBID_CONTENTS = _addToSet({}, [
+        'audio', 'head', 'math', 'script', 'style', 'svg', 'video'
+    ]);
+
+    /* Keep a reference to config to pass to hooks */
+    var CONFIG = null;
+
+    /* Ideally, do not touch anything below this line */
+    /* ______________________________________________ */
+
+    var formElement = document.createElement('form');
+
+    /**
+     * _parseConfig
+     *
+     * @param  optional config literal
+     */
+    var _parseConfig = function(cfg) {
+        /* Shield configuration object from tampering */
+        if (typeof cfg !== 'object') {
+            cfg = {};
+        }
+
+        /* Set configuration parameters */
+        ALLOWED_TAGS = 'ALLOWED_TAGS' in cfg ?
+            _addToSet({}, cfg.ALLOWED_TAGS) : DEFAULT_ALLOWED_TAGS;
+        ALLOWED_ATTR = 'ALLOWED_ATTR' in cfg ?
+            _addToSet({}, cfg.ALLOWED_ATTR) : DEFAULT_ALLOWED_ATTR;
+        FORBID_TAGS = 'FORBID_TAGS' in cfg ?
+            _addToSet({}, cfg.FORBID_TAGS) : {};
+        FORBID_ATTR = 'FORBID_ATTR' in cfg ?
+            _addToSet({}, cfg.FORBID_ATTR) : {};
+        ALLOW_DATA_ATTR     = cfg.ALLOW_DATA_ATTR     !== false; // Default true
+        SAFE_FOR_JQUERY     = cfg.SAFE_FOR_JQUERY     ||  false; // Default false
+        SAFE_FOR_TEMPLATES  = cfg.SAFE_FOR_TEMPLATES  ||  false; // Default false
+        WHOLE_DOCUMENT      = cfg.WHOLE_DOCUMENT      ||  false; // Default false
+        RETURN_DOM          = cfg.RETURN_DOM          ||  false; // Default false
+        RETURN_DOM_FRAGMENT = cfg.RETURN_DOM_FRAGMENT ||  false; // Default false
+        RETURN_DOM_IMPORT   = cfg.RETURN_DOM_IMPORT   ||  false; // Default false
+        SANITIZE_DOM        = cfg.SANITIZE_DOM        !== false; // Default true
+        KEEP_CONTENT        = cfg.KEEP_CONTENT        !== false; // Default true
+
+        if (RETURN_DOM_FRAGMENT) {
+            RETURN_DOM = true;
+        }
+
+        /* Merge configuration parameters */
+        if (cfg.ADD_TAGS) {
+            if (ALLOWED_TAGS === DEFAULT_ALLOWED_TAGS) {
+                ALLOWED_TAGS = _cloneObj(ALLOWED_TAGS);
+            }
+            _addToSet(ALLOWED_TAGS, cfg.ADD_TAGS);
+        }
+        if (cfg.ADD_ATTR) {
+            if (ALLOWED_ATTR === DEFAULT_ALLOWED_ATTR) {
+                ALLOWED_ATTR = _cloneObj(ALLOWED_ATTR);
+            }
+            _addToSet(ALLOWED_ATTR, cfg.ADD_ATTR);
+        }
+
+        /* Add #text in case KEEP_CONTENT is set to true */
+        if (KEEP_CONTENT) { ALLOWED_TAGS['#text'] = true; }
+
+        // Prevent further manipulation of configuration.
+        // Not available in IE8, Safari 5, etc.
+        if (Object && 'freeze' in Object) { Object.freeze(cfg); }
+
+        CONFIG = cfg;
+    };
+
+   /**
+     * _forceRemove
+     *
+     * @param  a DOM node
+     */
+    var _forceRemove = function(node) {
+        try {
+            node.parentNode.removeChild(node);
+        } catch (e) {
+            node.outerHTML = '';
+        }
+    };
+
+   /**
+     * _initDocument
+     *
+     * @param  a string of dirty markup
+     * @return a DOM, filled with the dirty markup
+     */
+    var _initDocument = function(dirty) {
+        /* Create a HTML document using DOMParser */
+        var doc, body;
+        try {
+            doc = new DOMParser().parseFromString(dirty, "text/html");
+        } catch (e) {}
+
+        /* Some browsers throw, some browsers return null for the code above
+           DOMParser with text/html support is only in very recent browsers. */
+        if (!doc){
+            doc = implementation.createHTMLDocument('');
+            body = doc.body;
+            body.parentNode.removeChild(body.parentNode.firstElementChild);
+            body.outerHTML = dirty;
+        }
+
+        /* Work on whole document or just its body */
+        if (typeof doc.getElementsByTagName === 'function'){
+            return doc.getElementsByTagName(
+                WHOLE_DOCUMENT ? 'html' : 'body')[0];
+        } else {
+            return getElementsByTagName.call(doc,
+                WHOLE_DOCUMENT ? 'html' : 'body')[0];
+        }
+    };
+
+    /**
+     * _createIterator
+     *
+     * @param  document/fragment to create iterator for
+     * @return iterator instance
+     */
+    var _createIterator = function(root) {
+        return createNodeIterator.call(root.ownerDocument || root,
+            root,
+            NodeFilter.SHOW_ELEMENT
+            | NodeFilter.SHOW_COMMENT
+            | NodeFilter.SHOW_TEXT,
+            function() { return NodeFilter.FILTER_ACCEPT; },
+            false
+        );
+    };
+
+    /**
+     * _isClobbered
+     *
+     * @param  element to check for clobbering attacks
+     * @return true if clobbered, false if safe
+     */
+    var _isClobbered = function(elm) {
+        if (elm instanceof Text || elm instanceof Comment) {
+            return false;
+        }
+        if (  typeof elm.nodeName !== 'string'
+           || typeof elm.textContent !== 'string'
+           || typeof elm.removeChild !== 'function'
+           || !(elm.attributes instanceof NamedNodeMap)
+           || typeof elm.removeAttribute !== 'function'
+           || typeof elm.setAttribute !== 'function'
+        ) {
+            return true;
+        }
+        return false;
+    };
+
+    /**
+     * _sanitizeElements
+     *
+     * @protect nodeName
+     * @protect textContent
+     * @protect removeChild
+     *
+     * @param   node to check for permission to exist
+     * @return  true if node was killed, false if left alive
+     */
+    var _sanitizeElements = function(currentNode) {
+        /* Execute a hook if present */
+        _executeHook('beforeSanitizeElements', currentNode, null);
+
+        /* Check if element is clobbered or can clobber */
+        if (_isClobbered(currentNode)) {
+            _forceRemove(currentNode);
+            return true;
+        }
+
+        /* Now let's check the element's type and name */
+        var tagName = currentNode.nodeName.toLowerCase();
+
+        /* Execute a hook if present */
+        _executeHook('uponSanitizeElement', currentNode, {
+            tagName: tagName
+        });
+
+        /* Remove element if anything forbids its presence */
+        if (!ALLOWED_TAGS[tagName] || FORBID_TAGS[tagName]) {
+            /* Keep content except for black-listed elements */
+            if (KEEP_CONTENT && !FORBID_CONTENTS[tagName]
+                    && typeof currentNode.insertAdjacentHTML === 'function') {
+                try {
+                    currentNode.insertAdjacentHTML('AfterEnd', currentNode.innerHTML);
+                } catch (e) {}
+            }
+            _forceRemove(currentNode);
+            return true;
+        }
+
+        /* Convert markup to cover jQuery behavior */
+        if (SAFE_FOR_JQUERY && !currentNode.firstElementChild 
+                && (!currentNode.content || !currentNode.content.firstElementChild)) {
+            currentNode.innerHTML = currentNode.textContent.replace(/</g, '&lt;');
+        }
+
+        /* Sanitize element content to be template-safe */
+        if(currentNode.nodeType === 3 && SAFE_FOR_TEMPLATES) {
+            /* Get the element's text content */
+            var content = currentNode.textContent;
+            content = content.replace(MUSTACHE_EXPR, ' ');
+            content = content.replace(ERB_EXPR, ' ');
+            currentNode.textContent = content;
+        }
+
+        /* Execute a hook if present */
+        _executeHook('afterSanitizeElements', currentNode, null);
+
+        return false;
+    };
+
+    /**
+     * _sanitizeAttributes
+     *
+     * @protect attributes
+     * @protect nodeName
+     * @protect removeAttribute
+     * @protect setAttribute
+     *
+     * @param   node to sanitize
+     * @return  void
+     */
+    var _sanitizeAttributes = function(currentNode) {
+        /* Execute a hook if present */
+        _executeHook('beforeSanitizeAttributes', currentNode, null);
+
+        var attributes = currentNode.attributes;
+
+        /* Check if we have attributes; if not we might have a text node */
+        if (!attributes) { return; }
+
+        var hookEvent = {
+            attrName: '',
+            attrValue: '',
+            keepAttr: true
+        };
+        var l = attributes.length;
+        var attr, name, value, lcName, idAttr;
+
+        /* Go backwards over all attributes; safely remove bad ones */
+        while (l--) {
+            attr = attributes[l];
+            name = attr.name;
+            value = attr.value;
+            lcName = name.toLowerCase();
+
+            /* Execute a hook if present */
+            hookEvent.attrName = lcName;
+            hookEvent.attrValue = value;
+            hookEvent.keepAttr = true;
+            _executeHook('uponSanitizeAttribute', currentNode, hookEvent );
+            value = hookEvent.attrValue;
+
+            /* Remove attribute */
+            // Safari (iOS + Mac), last tested v8.0.5, crashes if you try to
+            // remove a "name" attribute from an <img> tag that has an "id"
+            // attribute at the time.
+            if (lcName === 'name'  &&
+                    currentNode.nodeName === 'IMG' && attributes.id) {
+                idAttr = attributes.id;
+                attributes = Array.prototype.slice.apply(attributes);
+                currentNode.removeAttribute('id');
+                currentNode.removeAttribute(name);
+                if (attributes.indexOf(idAttr) > l) {
+                    currentNode.setAttribute('id', idAttr.value);
+                }
+            } else {
+                // This avoids a crash in Safari v9.0 with double-ids.
+                // The trick is to first set the id to be empty and then to 
+                // remove the attriubute
+                if (name === 'id') {
+                    currentNode.setAttribute(name, '');
+                }
+                currentNode.removeAttribute(name);
+            }
+
+            /* Did the hooks approve of the attribute? */
+            if (!hookEvent.keepAttr) {
+                continue;
+            }
+
+            /* Make sure attribute cannot clobber */
+            if (SANITIZE_DOM &&
+                    (lcName === 'id' || lcName === 'name') &&
+                    (value in window || value in document || value in formElement)) {
+                continue;
+            }
+
+            if (
+                /* Check the name is permitted */
+                (
+                 (ALLOWED_ATTR[lcName] && !FORBID_ATTR[lcName]) ||
+                 /* Allow potentially valid data-* attributes
+                    * At least one character after "-" (https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes)
+                    * XML-compatible (https://html.spec.whatwg.org/multipage/infrastructure.html#xml-compatible and http://www.w3.org/TR/xml/#d0e804) */
+                 (!SAFE_FOR_TEMPLATES && ALLOW_DATA_ATTR && DATA_ATTR.test(lcName))
+                ) &&
+                /* Get rid of script and data URIs */
+                (
+                 !IS_SCRIPT_OR_DATA.test(value.replace(ATTR_WHITESPACE,'')) ||
+                 /* Keep image data URIs alive if src is allowed */
+                 (lcName === 'src' && value.indexOf('data:') === 0 &&
+                  currentNode.nodeName === 'IMG')
+                )
+            ) {
+                /* Handle invalid data-* attribute set by try-catching it */
+                try {
+
+                    /* Sanitize attribute content to be template-safe */
+                    if (SAFE_FOR_TEMPLATES) {
+                        value = value.replace(MUSTACHE_EXPR, ' ');
+                        value = value.replace(ERB_EXPR, ' ');
+                        currentNode.setAttribute(name, value);
+                    }
+                    currentNode.setAttribute(name, value);
+                } catch (e) {}
+            }
+
+
+        }
+
+        /* Execute a hook if present */
+        _executeHook('afterSanitizeAttributes', currentNode, null);
+    };
+    var DATA_ATTR = /^data-[\w.\u00B7-\uFFFF-]/;
+    var IS_SCRIPT_OR_DATA = /^(?:\w+script|data):/i;
+    /* This needs to be extensive thanks to Webkit/Blink's behavior */
+    var ATTR_WHITESPACE = /[\x00-\x20\xA0\u1680\u180E\u2000-\u2029\u205f\u3000]/g;
+
+    var MUSTACHE_EXPR = /\{\{.*|.*\}\}/gm;
+    var ERB_EXPR = /<%.*|.*%>/gm;
+
+    /**
+     * _sanitizeShadowDOM
+     *
+     * @param  fragment to iterate over recursively
+     * @return void
+     */
+    var _sanitizeShadowDOM = function(fragment) {
+        var shadowNode;
+        var shadowIterator = _createIterator(fragment);
+
+        /* Execute a hook if present */
+        _executeHook('beforeSanitizeShadowDOM', fragment, null);
+
+        while ( (shadowNode = shadowIterator.nextNode()) ) {
+            /* Execute a hook if present */
+            _executeHook('uponSanitizeShadowNode', shadowNode, null);
+
+            /* Sanitize tags and elements */
+            if (_sanitizeElements(shadowNode)) {
+                continue;
+            }
+
+            /* Deep shadow DOM detected */
+            if (shadowNode.content instanceof DocumentFragment) {
+                _sanitizeShadowDOM(shadowNode.content);
+            }
+
+            /* Check attributes, sanitize if necessary */
+            _sanitizeAttributes(shadowNode);
+        }
+
+        /* Execute a hook if present */
+        _executeHook('afterSanitizeShadowDOM', fragment, null);
+    };
+
+    /**
+     * _executeHook
+     * Execute user configurable hooks
+     *
+     * @param  {String} entryPoint  Name of the hook's entry point
+     * @param  {Node} currentNode
+     */
+    var _executeHook = function(entryPoint, currentNode, data) {
+        if (!hooks[entryPoint]) { return; }
+
+        hooks[entryPoint].forEach(function(hook) {
+            hook.call(DOMPurify, currentNode, data, CONFIG);
+        });
+    };
+
+    /**
+     * sanitize
+     * Public method providing core sanitation functionality
+     *
+     * @param {String} dirty string
+     * @param {Object} configuration object
+     */
+    DOMPurify.sanitize = function(dirty, cfg) {
+        /* Return early if nothing to sanitize is given */
+        if (!dirty) {
+            return '';
+        }
+        
+        /* Stringify, in case dirty is an array */
+        if (dirty instanceof Array) {
+            dirty = dirty.toString();
+        }
+
+        /* Check we can run. Otherwise fall back or ignore */
+        if (!DOMPurify.isSupported) {
+            if (typeof window.toStaticHTML === 'object' && typeof dirty === 'string') {
+                return window.toStaticHTML(dirty);
+            }
+            return dirty;
+        }
+
+        /* Assign config vars */
+        _parseConfig(cfg);
+
+        /* Exit directly if we have nothing to do */
+        if (!RETURN_DOM && !WHOLE_DOCUMENT && dirty.indexOf('<') === -1) {
+            return dirty;
+        }
+
+        /* Initialize the document to work on */
+        var body = _initDocument(dirty);
+
+        /* Check we have a DOM node from the data */
+        if (!body) {
+            return RETURN_DOM ? null : '';
+        }
+
+        /* Get node iterator */
+        var currentNode;
+        var oldNode;
+        var nodeIterator = _createIterator(body);
+
+        /* Now start iterating over the created document */
+        while ( (currentNode = nodeIterator.nextNode()) ) {
+
+            /* Fix IE's strange behavior with manipulated textNodes #89 */
+            if (currentNode.nodeType === 3 && currentNode === oldNode) {
+                continue;
+            }
+
+            /* Sanitize tags and elements */
+            if (_sanitizeElements(currentNode)) {
+                continue;
+            }
+
+            /* Shadow DOM detected, sanitize it */
+            if (currentNode.content instanceof DocumentFragment) {
+                _sanitizeShadowDOM(currentNode.content);
+            }
+
+            /* Check attributes, sanitize if necessary */
+            _sanitizeAttributes(currentNode);
+
+            oldNode = currentNode;
+        }
+
+        /* Return sanitized string or DOM */
+        var returnNode;
+        if (RETURN_DOM) {
+
+            if (RETURN_DOM_FRAGMENT) {
+                returnNode = createDocumentFragment.call(body.ownerDocument);
+
+                while (body.firstChild) {
+                    returnNode.appendChild(body.firstChild);
+                }
+            } else {
+                returnNode = body;
+            }
+
+            if (RETURN_DOM_IMPORT) {
+                /* adoptNode() is not used because internal state is not reset
+                   (e.g. the past names map of a HTMLFormElement), this is safe
+                   in theory but we would rather not risk another attack vector.
+                   The state that is cloned by importNode() is explicitly defined
+                   by the specs. */
+                returnNode = importNode.call(originalDocument, returnNode, true);
+            }
+
+            return returnNode;
+        }
+
+        return WHOLE_DOCUMENT ? body.outerHTML : body.innerHTML;
+    };
+
+    /**
+     * addHook
+     * Public method to add DOMPurify hooks
+     *
+     * @param {String} entryPoint
+     * @param {Function} hookFunction
+     */
+    DOMPurify.addHook = function(entryPoint, hookFunction) {
+        if (typeof hookFunction !== 'function') { return; }
+        hooks[entryPoint] = hooks[entryPoint] || [];
+        hooks[entryPoint].push(hookFunction);
+    };
+
+    /**
+     * removeHook
+     * Public method to remove a DOMPurify hook at a given entryPoint
+     * (pops it from the stack of hooks if more are present)
+     *
+     * @param {String} entryPoint
+     * @return void
+     */
+    DOMPurify.removeHook = function(entryPoint) {
+        if (hooks[entryPoint]) {
+            hooks[entryPoint].pop();
+        }
+    };
+
+    /**
+     * removeHooks
+     * Public method to remove all DOMPurify hooks at a given entryPoint
+     *
+     * @param  {String} entryPoint
+     * @return void
+     */
+    DOMPurify.removeHooks = function(entryPoint) {
+        if (hooks[entryPoint]) {
+            hooks[entryPoint] = [];
+        }
+    };
+
+    /**
+     * removeAllHooks
+     * Public method to remove all DOMPurify hooks
+     *
+     * @return void
+     */
+    DOMPurify.removeAllHooks = function() {
+        hooks = [];
+    };
+
+    return DOMPurify;
+}));

--- a/www/js/submission.js
+++ b/www/js/submission.js
@@ -279,14 +279,12 @@ var submission = function($) {
 			$('#sampleLayout p').html(function(index){
 				if ($('#description').val().length) {
 					var string = $('#description').val().substring(0,300);
-					console.log(string);
 					//Purify it to match what the actual output would look like
 					string = DOMPurify.sanitize(string, {
 						ALLOWED_TAGS: ['a','strong','p','em'],
 						ALLOWED_ATTR: ['href'],
 						SAFE_FOR_JQUERY: true
 					});
-					console.log(string);
 					return string;
 				}
 			});

--- a/www/js/submission.js
+++ b/www/js/submission.js
@@ -282,7 +282,7 @@ var submission = function($) {
 					console.log(string);
 					//Purify it to match what the actual output would look like
 					string = DOMPurify.sanitize(string, {
-						ALLOWED_TAGS: ['a','strong','p','ul','ol','li','em'],
+						ALLOWED_TAGS: ['a','strong','p','em'],
 						ALLOWED_ATTR: ['href'],
 						SAFE_FOR_JQUERY: true
 					});

--- a/www/js/submission.js
+++ b/www/js/submission.js
@@ -82,8 +82,15 @@ var submission = function($) {
 			});
 
 			// Make a GoURL with campaign tagging for the Supporting Website
-			$('#website').bind('change', function() {
+			$('#website').bind('blur', function() {
 				var website = $.trim($(this).val());
+				
+				if ('' == website) {
+					//Handle an empty input
+					submission.updatePreview();
+					return;
+				}
+				
 				if (website.substring(0, 7) !== 'http://' && website.substring(0, 8) !== 'https://' && website.substring(0, 7) !== 'mailto:') {
 					website = 'http://' + website;
 				}
@@ -293,8 +300,15 @@ var submission = function($) {
 					return $('#title').val();
 				}
 			});
-			$('#sampleLayout a.supporting_website').text(function(index){
-				return $('#website').val();
+			$('#supporting_website').html(function(index){
+				var website = $('#website').val();
+				if (website.length) {
+					return $('<a>').attr({
+						href: website
+					}).text(website)
+				}
+				
+				return '';
 			});
 			var demoText = $('#description').val();
 			if ((submission.characterLimit - demoText.length) < (submission.characterLimit * .08)) {

--- a/www/js/submission.js
+++ b/www/js/submission.js
@@ -281,8 +281,8 @@ var submission = function($) {
 					var string = $('#description').val().substring(0,300);
 					//Purify it to match what the actual output would look like
 					string = DOMPurify.sanitize(string, {
-						ALLOWED_TAGS: ['a','strong','p','em'],
-						ALLOWED_ATTR: ['href'],
+						ALLOWED_TAGS: ENEWS_ALLOWED_TAGS_DESCRIPTION,
+						ALLOWED_ATTR: ENEWS_ALLOWED_ATTR_DESCRIPTION,
 						SAFE_FOR_JQUERY: true
 					});
 					return string;

--- a/www/js/submission.js
+++ b/www/js/submission.js
@@ -276,9 +276,18 @@ var submission = function($) {
 		},
 
 		updatePreview : function() {
-			$('#sampleLayout p').text(function(index){
+			$('#sampleLayout p').html(function(index){
 				if ($('#description').val().length) {
-					return $('#description').val().substring(0,300);
+					var string = $('#description').val().substring(0,300);
+					console.log(string);
+					//Purify it to match what the actual output would look like
+					string = DOMPurify.sanitize(string, {
+						ALLOWED_TAGS: ['a','strong','p','ul','ol','li','em'],
+						ALLOWED_ATTR: ['href'],
+						SAFE_FOR_JQUERY: true
+					});
+					console.log(string);
+					return string;
 				}
 			});
 			$('#sampleLayout h4').text(function(index){
@@ -286,7 +295,7 @@ var submission = function($) {
 					return $('#title').val();
 				}
 			});
-			$('#sampleLayout a').text(function(index){
+			$('#sampleLayout a.supporting_website').text(function(index){
 				return $('#website').val();
 			});
 			var demoText = $('#description').val();

--- a/www/templates/email/ENews/Newsletter/Story/Presentation/News/FullColImage.tpl.php
+++ b/www/templates/email/ENews/Newsletter/Story/Presentation/News/FullColImage.tpl.php
@@ -34,7 +34,7 @@ if ($context->getColFromSort() == 'onecol') {
                                             <td class="unltoday-body" align="top" style="font-size:18px;line-height:26px;font-family:Georgia,serif;color:#545350;border-bottom:2px solid #E7E2D6;padding:0 0 6px 0;">
                                                 <p>
                                                     <?php
-                                                    echo nl2br($context->description);
+                                                    echo $savvy->render($context, 'ENews/Story/field-description.tpl.php');
                                                     if (!empty($context->full_article)) {
                                                         echo ' <a href="'.$context->getURL().'" style="color:#BA0000;">Continue reading&hellip;</a>';
                                                     }

--- a/www/templates/email/ENews/Newsletter/Story/Presentation/News/FullTextFullColImage.tpl.php
+++ b/www/templates/email/ENews/Newsletter/Story/Presentation/News/FullTextFullColImage.tpl.php
@@ -33,7 +33,7 @@ if ($context->getColFromSort() == 'onecol') {
                                         <tr>
                                             <td class="unltoday-body" align="top" style="font-size:18px;line-height:26px;font-family:Georgia,serif;color:#545350;border-bottom:2px solid #E7E2D6;padding:0 0 6px 0;">
                                                 <p>
-                                                    <?php echo nl2br($context->full_article); ?>
+                                                    <?php echo $savvy->render($context, 'ENews/Story/field-full_article.tpl.php'); ?>
                                                     <?php if (isset($context->ics)): ?>
                                                         <a href="<?php echo $context->ics ?>" class="icsformat">Add to my calendar (.ics)</a>
                                                     <?php endif; ?>

--- a/www/templates/email/ENews/Newsletter/Story/Presentation/News/ThumbnailFloatedLeft.tpl.php
+++ b/www/templates/email/ENews/Newsletter/Story/Presentation/News/ThumbnailFloatedLeft.tpl.php
@@ -24,7 +24,7 @@
                                                     <?php endif; ?>
                                                     <p>
                                                     <?php
-                                                    echo nl2br($context->description);
+                                                    echo $savvy->render($context, 'ENews/Story/field-description.tpl.php');
                                                     if (!empty($context->full_article)) {
                                                         echo ' <a href="'.$context->getURL().'" style="color:#BA0000;">Continue reading&hellip;</a>';
                                                     }

--- a/www/templates/email/ENews/Newsletter/Story/Presentation/News/ThumbnailFloatedRight.tpl.php
+++ b/www/templates/email/ENews/Newsletter/Story/Presentation/News/ThumbnailFloatedRight.tpl.php
@@ -24,7 +24,7 @@
                                                 <?php endif; ?>
                                                 <p>
                                                     <?php
-                                                    echo nl2br($context->description);
+                                                    echo $savvy->render($context, 'ENews/Story/field-description.tpl.php');
                                                     if (!empty($context->full_article)) {
                                                         echo ' <a href="'.$context->getURL().'" style="color:#BA0000;">Continue reading&hellip;</a>';
                                                     }

--- a/www/templates/html/ENews/Newsletter/Story/Presentation/News/FullColImage.tpl.php
+++ b/www/templates/html/ENews/Newsletter/Story/Presentation/News/FullColImage.tpl.php
@@ -23,7 +23,7 @@ if ($file = $context->getFileByUse('originalimage')) {
 </h4>
 <p>
 <?php
-echo nl2br($context->description);
+echo $savvy->render($context, 'ENews/Story/field-description.tpl.php');
 if (!empty($context->full_article)) {
     echo ' <a href="'.$storylink.'">Continue reading&hellip;</a>';
 }

--- a/www/templates/html/ENews/Newsletter/Story/Presentation/News/FullTextFullColImage.tpl.php
+++ b/www/templates/html/ENews/Newsletter/Story/Presentation/News/FullTextFullColImage.tpl.php
@@ -18,7 +18,7 @@ if ($file = $context->getFileByUse('originalimage')) {
 </h4>
 <p>
 <?php
-echo nl2br($context->full_article);
+echo $savvy->render($context, 'ENews/Story/field-full_article.tpl.php');
 ?>
 <?php if (isset($context->ics)): ?>
 	<a href="<?php echo $context->ics ?>" class="icsformat">Add to my calendar (.ics)</a>

--- a/www/templates/html/ENews/Newsletter/Story/Summary.tpl.php
+++ b/www/templates/html/ENews/Newsletter/Story/Summary.tpl.php
@@ -18,5 +18,5 @@
     ?>
 	<h4><a href="<?php echo $storylink; ?>" title="Read more about <?php echo $context->title; ?>"><?php echo $context->title; ?></a></h4>
 
-	<p><?php echo nl2br($context->description); ?></p>
+	<p><?php echo $savvy->render($context, 'ENews/Story/field-description.tpl.php'); ?></p>
 </div>

--- a/www/templates/html/ENews/Story.tpl.php
+++ b/www/templates/html/ENews/Story.tpl.php
@@ -24,10 +24,10 @@ foreach ($context->getFiles() as $file) {
 <?php $full = trim($context->full_article); ?>
 <?php if (!empty($full)) : ?>
     <p>
-    <?php echo nl2br(UNL_ENews_Controller::makeClickableLinks($context->full_article)); ?>
+    <?php echo $savvy->render($context, 'ENews/Story/field-full_article.tpl.php'); ?>
     </p>
 <?php else : ?>
-    <?php echo nl2br($context->description); ?>
+    <?php echo $savvy->render($context, 'ENews/Story/field-description.tpl.php'); ?>
 <?php endif; ?>
 <?php if ($context->website) : ?>
     <p>

--- a/www/templates/html/ENews/Story/field-description.tpl.php
+++ b/www/templates/html/ENews/Story/field-description.tpl.php
@@ -1,6 +1,6 @@
 <?php
 $config = HTMLPurifier_Config::createDefault();
-$config->set('HTML.Allowed', "a[href],strong,p,ul,ol,li,em");
+$config->set('HTML.Allowed', "a[href],strong,p,em");
 $purifier = new HTMLPurifier($config);
 
 

--- a/www/templates/html/ENews/Story/field-description.tpl.php
+++ b/www/templates/html/ENews/Story/field-description.tpl.php
@@ -1,0 +1,10 @@
+<?php
+$config = HTMLPurifier_Config::createDefault();
+$config->set('HTML.Allowed', "a[href],strong,p,ul,ol,li,em");
+$purifier = new HTMLPurifier($config);
+
+
+$description = nl2br($context->getRawObject()->description);
+$description = $purifier->purify($description);
+
+echo $description;

--- a/www/templates/html/ENews/Story/field-description.tpl.php
+++ b/www/templates/html/ENews/Story/field-description.tpl.php
@@ -1,6 +1,6 @@
 <?php
 $config = HTMLPurifier_Config::createDefault();
-$config->set('HTML.Allowed', "a[href],strong,p,em");
+$config->set('HTML.Allowed', UNL_ENews_Controller::$allowed_html_field_description);
 $purifier = new HTMLPurifier($config);
 
 

--- a/www/templates/html/ENews/Story/field-description.tpl.php
+++ b/www/templates/html/ENews/Story/field-description.tpl.php
@@ -1,10 +1,10 @@
 <?php
 $config = HTMLPurifier_Config::createDefault();
 $config->set('HTML.Allowed', UNL_ENews_Controller::$allowed_html_field_description);
+$config->set('AutoFormat.Linkify', true);
 $purifier = new HTMLPurifier($config);
 
-
-$description = nl2br($context->getRawObject()->description);
+$description = nl2br(UNL_ENews_Controller::makeClickableLinks($context->getRawObject()->description));
 $description = $purifier->purify($description);
 
 echo $description;

--- a/www/templates/html/ENews/Story/field-full_article.tpl.php
+++ b/www/templates/html/ENews/Story/field-full_article.tpl.php
@@ -1,0 +1,10 @@
+<?php
+$config = HTMLPurifier_Config::createDefault();
+$config->set('HTML.Allowed', "a[href],strong,p,ul,ol,li,em");
+$purifier = new HTMLPurifier($config);
+
+
+$full_article = nl2br(UNL_ENews_Controller::makeClickableLinks($context->getRawObject()->full_article));
+$full_article = $purifier->purify($full_article);
+
+echo $full_article;

--- a/www/templates/html/ENews/Story/field-full_article.tpl.php
+++ b/www/templates/html/ENews/Story/field-full_article.tpl.php
@@ -1,6 +1,7 @@
 <?php
 $config = HTMLPurifier_Config::createDefault();
 $config->set('HTML.Allowed', UNL_ENews_Controller::$allowed_html_field_full_article);
+$config->set('AutoFormat.Linkify', true);
 $purifier = new HTMLPurifier($config);
 
 

--- a/www/templates/html/ENews/Story/field-full_article.tpl.php
+++ b/www/templates/html/ENews/Story/field-full_article.tpl.php
@@ -1,6 +1,6 @@
 <?php
 $config = HTMLPurifier_Config::createDefault();
-$config->set('HTML.Allowed', "a[href],strong,p,ul,ol,li,em");
+$config->set('HTML.Allowed', UNL_ENews_Controller::$allowed_html_field_full_article);
 $purifier = new HTMLPurifier($config);
 
 

--- a/www/templates/html/ENews/Submission.tpl.php
+++ b/www/templates/html/ENews/Submission.tpl.php
@@ -40,12 +40,12 @@ var ENEWS_DEFAULT_PRESENTATIONID = {<?php foreach ($types = array('news', 'event
 	var editType = false;
 <?php endif; ?>
 </script>
-<script type="text/javascript" src="/wdn/templates_3.0/scripts/plugins/ui/jQuery.ui.js"></script>
-<script type="text/javascript" src="<?php echo UNL_ENews_Controller::getURL();?>js/submission.js"></script>
-<script type="text/javascript" src="<?php echo UNL_ENews_Controller::getURL();?>js/purify.js"></script>
-<script type="text/javascript" src="<?php echo UNL_ENews_Controller::getURL();?>js/ajaxfileupload.js"></script>
-<script type="text/javascript" src="<?php echo UNL_ENews_Controller::getURL();?>js/jquery.textarearesizer.compressed.js"></script>
-<script type="text/javascript">
+<script src="/wdn/templates_3.0/scripts/plugins/ui/jQuery.ui.js"></script>
+<script src="<?php echo UNL_ENews_Controller::getURL();?>js/submission.js"></script>
+<script src="<?php echo UNL_ENews_Controller::getURL();?>js/purify.js"></script>
+<script src="<?php echo UNL_ENews_Controller::getURL();?>js/ajaxfileupload.js"></script>
+<script src="<?php echo UNL_ENews_Controller::getURL();?>js/jquery.textarearesizer.compressed.js"></script>
+<script>
     WDN.loadCSS("<?php echo UNL_ENews_Controller::getURL();?>css/imgareaselect-default.css");
     WDN.loadCSS("/wdn/templates_3.0/css/content/forms.css");
     WDN.loadCSS("/wdn/templates_3.0/scripts/plugins/ui/jquery-ui.css");

--- a/www/templates/html/ENews/Submission.tpl.php
+++ b/www/templates/html/ENews/Submission.tpl.php
@@ -231,7 +231,9 @@ if (UNL_ENews_Controller::getUser()->hasNewsroomPermission()) {
         <?php }  ?>
     </div>
     <p>&lt;Enter Your Article Text&gt;</p>
-    <a href="#" class="supporting_website"></a>
+        
+    <div id="supporting_website"></div>
+    
     <div class="clear"></div>
     </div>
 </div>

--- a/www/templates/html/ENews/Submission.tpl.php
+++ b/www/templates/html/ENews/Submission.tpl.php
@@ -39,6 +39,8 @@ var ENEWS_DEFAULT_PRESENTATIONID = {<?php foreach ($types = array('news', 'event
 <?php else :?>
 	var editType = false;
 <?php endif; ?>
+    var ENEWS_ALLOWED_TAGS_DESCRIPTION = <?php echo json_encode(UNL_ENews_Controller::$js_allowed_tags_description); ?>;
+    var ENEWS_ALLOWED_ATTR_DESCRIPTION = <?php echo json_encode(UNL_ENews_Controller::$js_allowed_attr_description); ?>;
 </script>
 <script src="/wdn/templates_3.0/scripts/plugins/ui/jQuery.ui.js"></script>
 <script src="<?php echo UNL_ENews_Controller::getURL();?>js/submission.js"></script>

--- a/www/templates/html/ENews/Submission.tpl.php
+++ b/www/templates/html/ENews/Submission.tpl.php
@@ -42,6 +42,7 @@ var ENEWS_DEFAULT_PRESENTATIONID = {<?php foreach ($types = array('news', 'event
 </script>
 <script type="text/javascript" src="/wdn/templates_3.0/scripts/plugins/ui/jQuery.ui.js"></script>
 <script type="text/javascript" src="<?php echo UNL_ENews_Controller::getURL();?>js/submission.js"></script>
+<script type="text/javascript" src="<?php echo UNL_ENews_Controller::getURL();?>js/purify.js"></script>
 <script type="text/javascript" src="<?php echo UNL_ENews_Controller::getURL();?>js/ajaxfileupload.js"></script>
 <script type="text/javascript" src="<?php echo UNL_ENews_Controller::getURL();?>js/jquery.textarearesizer.compressed.js"></script>
 <script type="text/javascript">
@@ -228,7 +229,7 @@ if (UNL_ENews_Controller::getUser()->hasNewsroomPermission()) {
         <?php }  ?>
     </div>
     <p>&lt;Enter Your Article Text&gt;</p>
-    <a href="#"></a>
+    <a href="#" class="supporting_website"></a>
     <div class="clear"></div>
     </div>
 </div>


### PR DESCRIPTION
HTML markup is limited in what elements and attributes can be used. It is also purified to prevent XSS attacks and fix invalid code.

description field allows
* a[href]
* strong
* p
* em

full_article field allows: 
* a[href]
* strong
* p
* em
* ul
* ol
* li

Lists are not allowed in the description field because they go against the purpose of a description (summary) paragraph and they don't play nice with images that are floated left/right in emails.

I'm not sure if I should provide a description of what elements are allowed for which fields in the interface. I almost don't want to encourage using these elements (because email clients are very picky), but maybe it wouldn't be a bad thing.

Demo is available here: 
http://ucommfairchild.unl.edu/mfairchild365/unl_enews/www/