### PR TITLE
Fix missing page titles from newsletter analytics report

### DIFF
--- a/src/UNL/ENews/PostRunFilter.php
+++ b/src/UNL/ENews/PostRunFilter.php
@@ -11,7 +11,8 @@ class UNL_ENews_PostRunFilter
     public static function postRun($data)
     {
         if (isset(self::$data['pagetitle'])) {
-            $data = str_replace('<title>Announce | University of Nebraska–Lincoln</title>',
+            
+            $data = str_replace('<title> | Announce | University of Nebraska–Lincoln</title>',
                                 '<title>'.self::$data['pagetitle'].' | Announce | University of Nebraska-Lincoln</title>',
             $data);
             $data = str_replace('<h1></h1>',

--- a/www/css/manage.css
+++ b/www/css/manage.css
@@ -99,3 +99,8 @@ form fieldset.storyFieldsetAction select {
     width:32px;
     height:32px;
 }
+body #cboxLoadedContent {
+    background-color: #fff;
+    padding: 1em;
+    border: 1px solid #3a3a3a;
+}

--- a/www/templates/html/ENews/GAStats.tpl.php
+++ b/www/templates/html/ENews/GAStats.tpl.php
@@ -24,7 +24,23 @@ if ($start_date==$end_date){
 foreach($context->response->getRows() as $result):
 ?>
 <tr>
-    <td><?php echo '<a href="http://'.$result[0].'">'.$result[1].'</a>' ?></td>
+    <?php
+    $title = trim(str_ireplace('| Announce | University of Nebraska–Lincoln', '', $result[1]));
+    
+    //If title is missing, try to find it (this shouldn't happen, but there was a bug preventing some story titles from being shown)
+    if (empty($title)) {
+        preg_match('/.*\/([\d]+)$/', $result[0], $matches);
+        if (isset($matches[1]) && $story = UNL_ENews_Story::getByID($matches[1])) {
+            $title = $story->title;
+        }
+    }
+    
+    //If the title is still empty... let the user know we don't know what it is
+    if (empty($title)) {
+        $title = 'unknown story';
+    }
+    ?>
+    <td><?php echo '<a href="http://'.$result[0].'">'.$title.'</a>' ?></td>
     <td><?php echo $result[2] // pageviews ?></td>
     <td><?php echo $result[3] // visits ?></td>
 </tr>


### PR DESCRIPTION
- Story titles were missing from the analytics report because they were not being adde to the `<title>` element (the post run filter was not matching correctly).
- This also tries to be smart and find the title based on the URL if it could not otherwise be found.
- Improve look of the colorbox that shows the analytics