### PR TITLE
use shib-cas

### DIFF
--- a/lib/php/UNL/Auth/SimpleCAS.php
+++ b/lib/php/UNL/Auth/SimpleCAS.php
@@ -47,9 +47,9 @@ class UNL_Auth_SimpleCAS extends UNL_Auth
      *
      * @var array
      */
-    protected $options = array('hostname' => 'login.unl.edu',
+    protected $options = array('hostname' => 'shib.unl.edu',
                                'port'     => 443,
-                               'uri'      => 'cas');
+                               'uri'      => '/idp/profile/cas');
     
     protected $client;
     


### PR DESCRIPTION
This updates the CAS configuration to use shib-cas.

Some notes:

- This directly edits the SimpleCAS library that is committed to the project (used to be managed via PEAR, but doesn't exist in composer).
- I had assumed that the better approach was to pass a new configuration option parameter to `UNL_Auth::factory('SimpleCAS', $options)`. This doesn't work. While the `SimpleCAS` constructor accepts such an option, the constructor is private, and the `getInstance()` method does not support an options parameter.
- Thus I was forced with either refactoring the entire library, or just updating the existing config in the library. I chose the easier of the two options.
- We will likely need to do something simalir in other projects

