### PR TITLE
Fix wrapper issue in Outlook 2016

### DIFF
--- a/www/templates/email/ENews/Newsletter/Story/Presentation/News/FullColImage.tpl.php
+++ b/www/templates/email/ENews/Newsletter/Story/Presentation/News/FullColImage.tpl.php
@@ -7,7 +7,7 @@ if ($context->getColFromSort() == 'onecol') {
 <table border="0" cellpadding="0" cellspacing="0" width="100%" style="line-height:normal">
     <tr>
         <td bgcolor="#f6f6f5" style="padding:10px 10px 10px 10px" class="unltoday-padding" align="center">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="responsive-table" style="max-width: 620px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="responsive-table" style="max-width: 650px;">
                 <tbody>
                 <tr>
                     <td valign="middle">

--- a/www/templates/email/ENews/Newsletter/Story/Presentation/News/FullTextFullColImage.tpl.php
+++ b/www/templates/email/ENews/Newsletter/Story/Presentation/News/FullTextFullColImage.tpl.php
@@ -7,7 +7,7 @@ if ($context->getColFromSort() == 'onecol') {
 <table border="0" cellpadding="0" cellspacing="0" width="100%" style="line-height:normal">
     <tr>
         <td bgcolor="#f6f6f5" style="padding:10px 10px 10px 10px" class="unltoday-padding" align="center">
-            <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="responsive-table" style="max-width: 620px;">
+            <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="responsive-table" style="max-width: 650px;">
                 <tbody>
                 <tr>
                     <td valign="middle">

--- a/www/templates/email/ENews/Newsletter/Story/Presentation/News/ThumbnailFloatedLeft.tpl.php
+++ b/www/templates/email/ENews/Newsletter/Story/Presentation/News/ThumbnailFloatedLeft.tpl.php
@@ -1,7 +1,7 @@
 <table border="0" cellpadding="0" cellspacing="0" width="100%" style="line-height:normal">
   <tr>
     <td bgcolor="#f6f6f5" style="padding:10px 10px 10px 10px" class="unltoday-padding" align="center">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="responsive-table" style="max-width: 620px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="responsive-table" style="max-width: 650px;">
         <tbody>
         <tr>
           <td valign="middle">

--- a/www/templates/email/ENews/Newsletter/Story/Presentation/News/ThumbnailFloatedRight.tpl.php
+++ b/www/templates/email/ENews/Newsletter/Story/Presentation/News/ThumbnailFloatedRight.tpl.php
@@ -1,7 +1,7 @@
 <table border="0" cellpadding="0" cellspacing="0" width="100%" style="line-height:normal">
   <tr>
     <td bgcolor="#f6f6f5" style="padding:10px 10px 10px 10px" class="unltoday-padding" align="center">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="responsive-table" style="max-width: 620px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" class="responsive-table" style="max-width: 650px;">
         <tbody>
         <tr>
           <td valign="middle">

--- a/www/templates/html/ENews/Newsletter/Stories.tpl.php
+++ b/www/templates/html/ENews/Newsletter/Stories.tpl.php
@@ -6,12 +6,18 @@
     ?>
     <?php if ($displayColumn): ?>
     <tr>
-        <td colspan="3" valign="top">
-            <?php echo $savvy->render($context->getStoryColumn($stories[1], array(
-                'area' => $area,
-                'offset' => 1,
-                'preview' => $isPreview
-            ))); ?>
+        <td align="center" colspan="3" valign="top">
+            <table width="620" cellpadding="0" cellspacing="0" style="max-width:620px;">
+                <tr>
+                    <td>
+                        <?php echo $savvy->render($context->getStoryColumn($stories[1], array(
+                            'area' => $area,
+                            'offset' => 1,
+                            'preview' => $isPreview
+                        ))); ?>
+                    </td>
+                </tr>
+            </table>
         </td>
     </tr>
     <?php endif; ?>

--- a/www/templates/html/ENews/Newsletter/Stories.tpl.php
+++ b/www/templates/html/ENews/Newsletter/Stories.tpl.php
@@ -7,7 +7,7 @@
     <?php if ($displayColumn): ?>
     <tr>
         <td align="center" colspan="3" valign="top">
-            <table width="620" cellpadding="0" cellspacing="0" style="max-width:620px;">
+            <table width="650" cellpadding="0" cellspacing="0" style="max-width:650px;">
                 <tr>
                     <td>
                         <?php echo $savvy->render($context->getStoryColumn($stories[1], array(
@@ -31,7 +31,7 @@
     <?php if ($displayColumn): ?>
     <tr>
         <td align="center">
-            <table width="620" cellpadding="0" cellspacing="0" style="max-width:620px;">
+            <table width="650" cellpadding="0" cellspacing="0" style="max-width:650px;">
                 <tr>
                     <td valign="top" class="responsive-column">
                          <?php echo $savvy->render($context->getStoryColumn($stories[2], array(


### PR DESCRIPTION
In Outlook 2016 the stories in the top section force themselves to be 100% of the window width and  force expand the tables we currently have.