### PR TITLE
Fix synchronizeWithArray()

### DIFF
--- a/src/UNL/ENews/Record.php
+++ b/src/UNL/ENews/Record.php
@@ -350,7 +350,7 @@ class UNL_ENews_Record
     {
         foreach (get_object_vars($this) as $key=>$default_value) {
             if (isset($data[$key])) {
-                if ($data[$key] == '') {
+                if (trim($data[$key]) == '') {
                     // Set the submission of an empty value to NULL so the database NULL constraint can handle validation.
                     $this->$key = NULL;
                 } else {

--- a/src/UNL/ENews/Record.php
+++ b/src/UNL/ENews/Record.php
@@ -349,8 +349,13 @@ class UNL_ENews_Record
     function synchronizeWithArray($data)
     {
         foreach (get_object_vars($this) as $key=>$default_value) {
-            if (isset($data[$key]) && !empty($data[$key])) {
-                $this->$key = $data[$key];
+            if (isset($data[$key])) {
+                if ($data[$key] == '') {
+                    // Set the submission of an empty value to NULL so the database NULL constraint can handle validation.
+                    $this->$key = NULL;
+                } else {
+                    $this->$key = $data[$key];
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #88 

This solves two things:
1) Can't clear out a field that has a value in it.  As see in: #88 Can't delete a newsroom's Subtitle once a value has been set.
2) Server-side validation was not working; required fields could be saved with empty strings. Now we change an empty string to NULL to allow the application's framework to use the presence of the database's NULL constraint to handle validation.