### PR TITLE
Added private newsletter webview option for a newsroom fixes #110

### DIFF
--- a/data/enews.sql
+++ b/data/enews.sql
@@ -86,14 +86,15 @@ CREATE TABLE IF NOT EXISTS `newsletter_stories` (
 --
 -- Table structure for table `newsrooms`
 --
-
 CREATE TABLE IF NOT EXISTS `newsrooms` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
+  `subtitle` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL,
   `shortname` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
   `website` varchar(250) COLLATE utf8_unicode_ci DEFAULT NULL,
   `email_lists` varchar(512) COLLATE utf8_unicode_ci DEFAULT NULL,
   `allow_submissions` tinyint(1) NOT NULL DEFAULT '1',
+  `private_web_view` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `shortname` (`shortname`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/data/enews_sample_data.sql
+++ b/data/enews_sample_data.sql
@@ -103,10 +103,12 @@ INSERT INTO `newsletter_stories` (`newsletter_id`, `story_id`, `sort_order`, `in
 CREATE TABLE IF NOT EXISTS `newsrooms` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
+  `subtitle` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL,
   `shortname` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
   `website` varchar(250) COLLATE utf8_unicode_ci DEFAULT NULL,
   `email_lists` varchar(512) COLLATE utf8_unicode_ci DEFAULT NULL,
   `allow_submissions` tinyint(1) NOT NULL DEFAULT '1',
+  `private_web_view` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `shortname` (`shortname`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=5 ;
@@ -115,11 +117,11 @@ CREATE TABLE IF NOT EXISTS `newsrooms` (
 -- Dumping data for table `newsrooms`
 --
 
-INSERT INTO `newsrooms` (`id`, `name`, `shortname`, `website`, `email_lists`, `allow_submissions`) VALUES
-(1, 'Today@UNL', 'todayatunl', 'http://newsroom.unl.edu/announce/todayatunl/', NULL, 1),
-(2, 'UNL Today', 'unltoday', 'http://www.unl.edu/ucomm/unltoday/', NULL, 0),
-(3, 'The Scarlet', 'scarlet', 'http://scarlet.unl.edu/', NULL, 0),
-(4, 'News Release', 'newsrelease', 'http://newsroom.unl.edu/releases/', NULL, 0);
+INSERT INTO `newsrooms` (`id`, `name`, `shortname`, `website`, `email_lists`, `allow_submissions`, `private_web_view`) VALUES
+(1, 'Today@UNL', 'todayatunl', 'http://newsroom.unl.edu/announce/todayatunl/', NULL, 1, 0),
+(2, 'UNL Today', 'unltoday', 'http://www.unl.edu/ucomm/unltoday/', NULL, 0, 0),
+(3, 'The Scarlet', 'scarlet', 'http://scarlet.unl.edu/', NULL, 0, 0),
+(4, 'News Release', 'newsrelease', 'http://newsroom.unl.edu/releases/', NULL, 0, 0);
 
 -- --------------------------------------------------------
 

--- a/scripts/addNewsroom.php
+++ b/scripts/addNewsroom.php
@@ -28,6 +28,7 @@ $newsroom->name              = $_SERVER['argv'][1];
 $newsroom->shortname         = $_SERVER['argv'][1];
 $newsroom->footer_text       = ' ';
 $newsroom->allow_submissions = 1;
+$newsroom->private_web_view = 0;
 
 if (!$newsroom->insert()) {
     echo 'Error creating the newsroom!'.PHP_EOL;

--- a/src/UNL/ENews/Admin/AddNewsroom.php
+++ b/src/UNL/ENews/Admin/AddNewsroom.php
@@ -22,6 +22,13 @@ class UNL_ENews_Admin_AddNewsroom extends UNL_ENews_Admin_LoginRequired
                     $newsroom->allow_submissions = 0;
                 }
 
+                if (isset($_POST['private_web_view'])
+                && $_POST['private_web_view'] == 'on') {
+                    $newsroom->private_web_view = 1;
+                } else {
+                    $newsroom->private_web_view = 0;
+                }
+
                 if (empty($newsroom->footer_text)) {
                     $newsroom->footer_text = ' ';
                 }

--- a/src/UNL/ENews/Manager.php
+++ b/src/UNL/ENews/Manager.php
@@ -64,18 +64,16 @@ class UNL_ENews_Manager extends UNL_ENews_LoginRequired
                     throw new Exception('you cannot modify a newsroom you don\'t have permission to!', 403);
                 }
 
-                if (isset($_POST['allow_submissions'])
-                    && $_POST['allow_submissions'] == 'on') {
+                if (isset($_POST['allow_submissions']) && $_POST['allow_submissions'] == 'on') {
                     $_POST['allow_submissions'] = 1;
                 } else {
                     $_POST['allow_submissions'] = 0;
                 }
 
-                if (isset($_POST['private_web_view'])
-                && $_POST['private_web_view'] == 'on') {
-                $_POST['private_web_view'] = 1;
+                if (isset($_POST['private_web_view']) && $_POST['private_web_view'] == 'on') {
+                    $_POST['private_web_view'] = 1;
                 } else {
-                $_POST['private_web_view'] = 0;
+                    $_POST['private_web_view'] = 0;
                 }
 
                 $newsroom->synchronizeWithArray($_POST);

--- a/src/UNL/ENews/Manager.php
+++ b/src/UNL/ENews/Manager.php
@@ -70,6 +70,14 @@ class UNL_ENews_Manager extends UNL_ENews_LoginRequired
                 } else {
                     $_POST['allow_submissions'] = 0;
                 }
+
+                if (isset($_POST['private_web_view'])
+                && $_POST['private_web_view'] == 'on') {
+                $_POST['private_web_view'] = 1;
+                } else {
+                $_POST['private_web_view'] = 0;
+                }
+
                 $newsroom->synchronizeWithArray($_POST);
                 $newsroom->save();
 

--- a/src/UNL/ENews/Newsletter/Public.php
+++ b/src/UNL/ENews/Newsletter/Public.php
@@ -29,7 +29,7 @@ class UNL_ENews_Newsletter_Public
     }
 
 
-    function setNewsroom()
+    private function setNewsroom()
     {   
         if (isset($this->options['shortname'])) {
             if (UNL_ENews_Newsroom::getByShortname($this->options['shortname'])) {
@@ -41,7 +41,7 @@ class UNL_ENews_Newsletter_Public
         }
     }
 
-    function setNewsletter()
+    private function setNewsletter()
     {
         if (isset($this->options['id'])) {
             $this->newsletter = UNL_ENews_Newsletter::getById($this->options['id']);
@@ -51,7 +51,7 @@ class UNL_ENews_Newsletter_Public
         }
     }
 
-    function newsletterIdCheck()
+    private function newsletterIdCheck()
     {
         if (isset($this->options['id'])) {
             return true;
@@ -60,7 +60,7 @@ class UNL_ENews_Newsletter_Public
         }
     }
 
-    function validateNewsletter()
+    private function validateNewsletter()
     {
         // If a newsroom name was passed, verify that the newsroom is correct
         if (isset($this->options['shortname'])) {
@@ -81,7 +81,7 @@ class UNL_ENews_Newsletter_Public
         $this->requestLogin();
     }
 
-    function setLastRealeasedNewsletter($id)
+    private function setLastRealeasedNewsletter($id)
     {
         $this->newsletter = UNL_ENews_Newsletter::getLastReleased($id);
         if (!$this->newsletter && isset($id)) {
@@ -92,7 +92,7 @@ class UNL_ENews_Newsletter_Public
         }
     }
 
-    function requestLogin()
+    private function requestLogin()
     {
         $this->setNewsroom();
         if ($this->newsroom) {

--- a/src/UNL/ENews/Newsletter/Public.php
+++ b/src/UNL/ENews/Newsletter/Public.php
@@ -1,5 +1,5 @@
 <?php
-class UNL_ENews_Newsletter_Public 
+class UNL_ENews_Newsletter_Public
 {
     /**
      * The newsletter
@@ -7,69 +7,102 @@ class UNL_ENews_Newsletter_Public
      * @var UNL_ENews_Newsletter
      */
     public $newsletter;
-    public $newsroom;
- 
+    private $newsroom;
+    private $options;
+
     function __construct($options = array())
     {
-        if (isset($options['id'])) {
-                       // Open the newsletter requested
-            $this->newsletter = UNL_ENews_Newsletter::getById($options['id']);
+        $this->options = $options;
+
+        if ($this->newsletterIdCheck()) {
+            $this->setNewsletter();
+            $this->validateNewsletter();
+        } else {
+            //I don't know if we need this logic for checking shortname. When adding a newsroom, shortname is a required field. 
+            if (isset($this->options['shortname'])) {
+                $this->requestLogin();
+                $this->setLastRealeasedNewsletter($this->newsroom->id);
+            } else {
+                $this->setLastRealeasedNewsletter(NULL);
+            }
+        }
+    }
+
+
+    function setNewsroom()
+    {   
+        if (isset($this->options['shortname'])) {
+            if (UNL_ENews_Newsroom::getByShortname($this->options['shortname'])) {
+                $this->newsroom = UNL_ENews_Newsroom::getByShortname($this->options['shortname']);
+            }
+            if (!$this->newsroom) {
+                throw new Exception('There are no newsrooms by that name.', 404);
+            }
+        }
+    }
+
+    function setNewsletter()
+    {
+        if (isset($this->options['id'])) {
+            $this->newsletter = UNL_ENews_Newsletter::getById($this->options['id']);
             if (!$this->newsletter) {
                 throw new Exception('Could not find that newsletter', 404);
             }
+        }
+    }
 
-            // If a newsroom name was passed, verify that the newsroom is correct
-            if (isset($options['shortname'])) {
-                if ($this->newsletter->newsroom->shortname != $options['shortname']) {
-                    throw new Exception('This newsletter does not belong in this newsroom.', 404);
-                }
+    function newsletterIdCheck()
+    {
+        if (isset($this->options['id'])) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    function validateNewsletter()
+    {
+        // If a newsroom name was passed, verify that the newsroom is correct
+        if (isset($this->options['shortname'])) {
+            //using the magic method __get(). Do we want to do it this way?
+            if ($this->newsletter->newsroom->shortname != $this->options['shortname']) {
+                throw new Exception('This newsletter does not belong in this newsroom.', 404);
             }
+        }
 
-            // If this is an unpublished newsletter, check permissions
-            if ((empty($this->newsletter->release_date)
+        // If this is an unpublished newsletter, check permissions
+        if ((empty($this->newsletter->release_date)
                 || ($this->newsletter->release_date > date('Y-m-d H:i:s')))
-                && !UNL_ENews_Controller::getUser(true)->hasNewsroomPermission($this->newsletter->newsroom_id)) {
-                throw new Exception('You do not have permission to view unpublished newsletters for this newsroom', 403);
-            }
+            && !UNL_ENews_Controller::getUser(true)->hasNewsroomPermission($this->newsletter->newsroom_id)
+        ) {
+            throw new Exception('You do not have permission to view unpublished newsletters for this newsroom', 403);
+        }
 
+        $this->requestLogin();
+    }
+
+    function setLastRealeasedNewsletter($id)
+    {
+        $this->newsletter = UNL_ENews_Newsletter::getLastReleased($id);
+        if (!$this->newsletter && isset($id)) {
+            throw new Exception('There are no published newsletters for this newsroom.', 404);
+        //I don't think we need this elseif
+        } elseif (!$this->newsletter) {
+            throw new Exception('There are no published newsletters.', 404);
+        }
+    }
+
+    function requestLogin()
+    {
+        $this->setNewsroom();
+        if ($this->newsroom) {
             //Check if newsletter webview is only allowed for UNL-authenticated users
-            if ($this->newsroom = UNL_ENews_Newsroom::getByShortname($options['shortname'])) {
-                if(isset($this->newsroom->private_web_view) and $this->newsroom->private_web_view === '1' ) {
-                    //Request login
-                    if (empty(UNL_ENews_Controller::authenticate())) {
-                        throw new Exception('You do not have access to view this newsletter page', 404);
-                    }
-                }
-            }
-        } else { 
-            if (isset($options['shortname'])) {
-                if ($this->newsroom = UNL_ENews_Newsroom::getByShortname($options['shortname'])) {
-                    //Check if newsletter webview is only allowed for UNL-authenticated users
-                    if(isset($this->newsroom->private_web_view) and $this->newsroom->private_web_view === '1' ) {
-                        if (empty(UNL_ENews_Controller::authenticate())) {
-                            throw new Exception('You do not have access to view this newsletter page', 404);
-                        }
-
-                        $this->newsletter = UNL_ENews_Newsletter::getLastReleased($this->newsroom->id);
-                        if (!$this->newsletter) {
-                          throw new Exception('There are no published newsletters for this newsroom.', 404);
-                        }
-                    } else {
-                        $this->newsletter = UNL_ENews_Newsletter::getLastReleased($this->newsroom->id);
-                        if (!$this->newsletter) {
-                          throw new Exception('There are no published newsletters for this newsroom.', 404);
-                        }
-                    }
-                } else {
-                    throw new Exception('There are no newsrooms by that name.', 404);
-                }  
-            } else {
-                $this->newsletter = UNL_ENews_Newsletter::getLastReleased(NULL);
-                if (!$this->newsletter) {
-                    throw new Exception('There are no published newsletters.', 404);
+            if (isset($this->newsroom->private_web_view) && $this->newsroom->private_web_view === '1') {
+                //Request login
+                if (empty(UNL_ENews_Controller::authenticate())) {
+                    throw new Exception('You do not have access to view this newsletter page', 404);
                 }
             }
         }
     }
-    
 }

--- a/src/UNL/ENews/Newsletter/Public.php
+++ b/src/UNL/ENews/Newsletter/Public.php
@@ -18,7 +18,6 @@ class UNL_ENews_Newsletter_Public
             $this->setNewsletter();
             $this->validateNewsletter();
         } else {
-            //I don't know if we need this logic for checking shortname. When adding a newsroom, shortname is a required field. 
             if (isset($this->options['shortname'])) {
                 $this->requestLogin();
                 $this->setLastRealeasedNewsletter($this->newsroom->id);
@@ -64,7 +63,6 @@ class UNL_ENews_Newsletter_Public
     {
         // If a newsroom name was passed, verify that the newsroom is correct
         if (isset($this->options['shortname'])) {
-            //using the magic method __get(). Do we want to do it this way?
             if ($this->newsletter->newsroom->shortname != $this->options['shortname']) {
                 throw new Exception('This newsletter does not belong in this newsroom.', 404);
             }
@@ -86,7 +84,6 @@ class UNL_ENews_Newsletter_Public
         $this->newsletter = UNL_ENews_Newsletter::getLastReleased($id);
         if (!$this->newsletter && isset($id)) {
             throw new Exception('There are no published newsletters for this newsroom.', 404);
-        //I don't think we need this elseif
         } elseif (!$this->newsletter) {
             throw new Exception('There are no published newsletters.', 404);
         }

--- a/src/UNL/ENews/Newsletter/Story.php
+++ b/src/UNL/ENews/Newsletter/Story.php
@@ -71,7 +71,7 @@ class UNL_ENews_Newsletter_Story extends UNL_ENews_Record
                 throw new Exception('Not a valid newsroom name.', 400);
             }
 
-            if(isset($this->newsroom->private_web_view) and $this->newsroom->private_web_view === '1' ) {
+            if(isset($this->newsroom->private_web_view) && $this->newsroom->private_web_view === '1' ) {
                 if (empty(UNL_ENews_Controller::authenticate())) {
                     throw new Exception('You do not have access to view this newsletter page', 404);
                 }                

--- a/src/UNL/ENews/Newsletter/Story.php
+++ b/src/UNL/ENews/Newsletter/Story.php
@@ -70,6 +70,12 @@ class UNL_ENews_Newsletter_Story extends UNL_ENews_Record
             if (!($this->newsroom->shortname == $options['shortname'])) {
                 throw new Exception('Not a valid newsroom name.', 400);
             }
+
+            if(isset($this->newsroom->private_web_view) and $this->newsroom->private_web_view === '1' ) {
+                if (empty(UNL_ENews_Controller::authenticate())) {
+                    throw new Exception('You do not have access to view this newsletter page', 404);
+                }                
+            }
         }
     }
 

--- a/src/UNL/ENews/Newsletter/Story.php
+++ b/src/UNL/ENews/Newsletter/Story.php
@@ -71,7 +71,7 @@ class UNL_ENews_Newsletter_Story extends UNL_ENews_Record
                 throw new Exception('Not a valid newsroom name.', 400);
             }
 
-            if(isset($this->newsroom->private_web_view) && $this->newsroom->private_web_view === '1' ) {
+            if (isset($this->newsroom->private_web_view) && $this->newsroom->private_web_view === '1') {
                 if (empty(UNL_ENews_Controller::authenticate())) {
                     throw new Exception('You do not have access to view this newsletter page', 404);
                 }                

--- a/src/UNL/ENews/Newsroom.php
+++ b/src/UNL/ENews/Newsroom.php
@@ -21,6 +21,8 @@ class UNL_ENews_Newsroom extends UNL_ENews_Record
 
     public $submit_url;
 
+    public $private_web_view;
+
     function __construct($options = array())
     {
 

--- a/upgrade.php
+++ b/upgrade.php
@@ -63,6 +63,14 @@ if (!$result) {
     }
 }
 
+echo 'Adding private_web_view column to the newsrooms table...<br />'.PHP_EOL;
+$result = $mysqli->query("ALTER TABLE `newsrooms` ADD `private_web_view` tinyint(1) NOT NULL DEFAULT 0;");
+if (!$result) {
+    if (mysqli_errno($mysqli) == 1060) {
+        echo 'Field already has been added<br />'.PHP_EOL;
+    }
+}
+
 $result = $mysqli->query("SELECT id, email_lists FROM newsrooms;");
 if ($result) {
     while ($row = $result->fetch_assoc()) {

--- a/www/templates/html/ENews/Newsroom/EditForm.tpl.php
+++ b/www/templates/html/ENews/Newsroom/EditForm.tpl.php
@@ -62,6 +62,12 @@ WDN.loadCSS('" . UNL_ENews_Controller::getURL(). "css/newsroom.css');
                 Allow Submissions <span class="dcf-form-help">Can users send news items for review?</span>
             </label>
         </li>
+        <li class="dcf-input-checkbox">
+            <input class="dcf-input-control" type="checkbox" id="private_web_view" name="private_web_view" <?php echo ($context->private_web_view)? 'checked="checked"': ''; ?> />
+            <label class="dcf-label" for="private_web_view">
+                Private Web View <span class="dcf-form-help">Newsletter webpages will only be viewable to UNL-authenticated users</span>
+            </label>
+        </li>
         <?php if ($context->id) : ?>
         <li>
             <label class="dcf-label" for="submit_url">Submit News URL


### PR DESCRIPTION
### _April 10, 2024_ 

I think it's good to go for a review. I would like to mention that Sonar Cloud does not like some of the existing code in the enews_sample_sata.sql, enews.sql, and upgrade.php files. Should I refactor those?

### _April 8, 2024_
First version of the code. Still testing to make sure everything works right.

I can change some of the labels and/or descriptions for the newsletter private web view option. 

When we add a new column to the database, what's the procedure for updating the main server's database? Should I attach an SQL file to the issue, containing the ALTER TABLE SQL commands needed to make the changes?

I can create some functions like 'getNewsroom' and 'Authenticate' in the UNL_ENews_Newsletter_Public file that can be referenced by the constructor in that file if it will help clean up some code.

closes #110 