### PR TITLE
Add term to pagination link base

### DIFF
--- a/www/templates/html/ENews/Newsroom/Stories.tpl.php
+++ b/www/templates/html/ENews/Newsroom/Stories.tpl.php
@@ -177,7 +177,7 @@ if (isset($context->options['limit']) && count($context) > $context->options['li
 	$pager->total  = count($context);
 	$pager->limit  = $context->options['limit'];
 	$pager->offset = $context->options['offset'];
-	$pager->url    = $context->getManageURL(array('status'=>$status));
+	$pager->url    = $context->getManageURL(array('status'=>$status, 'term'=> $term));
 	echo $savvy->render($pager, 'ENews/PaginationLinks.tpl.php');
 }
 ?>


### PR DESCRIPTION
Fix pagination links to include term in url params. This was preventing people from looking at page two of story searches