### PR TITLE
Fix archive message and image overlap

### DIFF
--- a/www/templates/html/ENews/Story.tpl.php
+++ b/www/templates/html/ENews/Story.tpl.php
@@ -1,6 +1,18 @@
 <?php
 UNL_ENews_PostRunFilter::setReplacementData('pagetitle', $context->title);
 ?>
+
+<?php if (
+    strtotime($context->request_publish_end) < strtotime('-1 year') ||
+    strtotime($context->date_modified) < strtotime('-3 year') ||
+    strtotime($context->date_submitted) < strtotime('-3 year')
+): ?>
+<div class="dcf-clear-both unl-bg-scarlet unl-cream dcf-rounded dcf-p-3 dcf-mb-3">
+    <strong>Archived Story:</strong> This article is part of our newsletter archives. It has
+    been preserved for reference, but the information may no longer be current.
+</div>
+<?php endif; ?>
+
 <?php
 foreach ($context->getFiles() as $file) {
     if (preg_match('/^image/', $file->type) && $file->use_for == 'originalimage') {
@@ -20,17 +32,6 @@ foreach ($context->getFiles() as $file) {
     }
 }
 ?>
-
-<?php if (
-    strtotime($context->request_publish_end) < strtotime('-1 year') ||
-    strtotime($context->date_modified) < strtotime('-3 year') ||
-    strtotime($context->date_submitted) < strtotime('-3 year')
-): ?>
-<div class="unl-bg-scarlet unl-cream dcf-rounded dcf-p-3 dcf-mb-3">
-    <strong>Archived Story:</strong> This article is part of our newsletter archives. It has
-    been preserved for reference, but the information may no longer be current.
-</div>
-<?php endif ?>
 
 <?php $full = trim($context->full_article); ?>
 <?php if (!empty($full)) : ?>


### PR DESCRIPTION
Changes:

- Moved archive message before story image
- Added `.dcf-clear-both` to archive message